### PR TITLE
New 'image_attr' option

### DIFF
--- a/src/hw-parallax.js
+++ b/src/hw-parallax.js
@@ -59,14 +59,15 @@
     init: function() {
       this.scroll_factor = this.options.scroll_factor;
       var parallax_blocks = this.parallax_blocks = [];
+      var image_attr = this.options.image_attr
 
       var $body = $('body');
       var $origins = this.options.origins;
       $origins.each(function() {
         var $origin = $(this);
         var $parallax_block;
-        if ($origin.data(this.options.image_attr)) {
-          $parallax_block = $('<div class="parallax-block"><img class="parallax-image" src="' + $origin.data(this.options.image_attr) + '"></div>');
+        if ($origin.data(image_attr)) {
+          $parallax_block = $('<div class="parallax-block"><img class="parallax-image" src="' + $origin.data(image_attr) + '"></div>');
           parallax_blocks.push({
             origin: $origin,
             block: $parallax_block,


### PR DESCRIPTION
Allows alternative 'data-image-mobile' attribute to be specified for loading mobile optimised images:
##### HTML

``` HTML
<div data-image="image_source_relative_to_page" data-image-mobile="mobile_image_source"
data-width="image_width_in_pixels" data-height="image_height_in_pixels">
```

The `data-wdith` and `data-height` attributes still refer to the main full-size image and don't need repeating as they're only used to calculate the image aspect-ratio.
##### JavaScript

To use this option, specify which `image_attr` to use when initialising parallax().

``` javascript
var touch = Modernizr.touch;
$('.parallax').parallax({
  image_attr: (touch) ? 'image-mobile' : 'image',
  scroll_factor: 0.5
});
```

_Attribution_: idea and implementation lifted pretty much wholesale from https://github.com/pederan/Parallax-ImageScroll.
