### PR TITLE
Fix background flicker on resize (in Firefox)

### DIFF
--- a/src/hw-parallax.js
+++ b/src/hw-parallax.js
@@ -133,7 +133,7 @@
         $parallax_image.width(img_width).height(img_height);
 
         // Set the dimensions of the parallax block and hide it
-        $parallax_block.width(window_width).height(origin_height).css('visibility', 'hidden');
+        $parallax_block.width(window_width).height(origin_height);
 
         // Cache some data about the parallax block so that we don't have to recalculate it on every tick
         // This data potentially changes, only changes when the window is resized


### PR DESCRIPTION
Hi Ziad,

first, thanks a lot for sharing this plugin! Very nice job.

I've been using it for some time now. The only issue I've encounterd is that, in Firefox, background images flicker while you're resizing the browser.

This seems to happen because visibility is set to hidden in the redrawBlocks method and immediately after it is set to visible by the draw method.

It seems safe to remove the first change of visibility, since the draw method has an if-else statement that will set the visibility to hidden or visible, and the draw method is always called after the redrawBlocks method.

Thanks again,

Jordi
